### PR TITLE
fix: add explicit files whitelist for npm publish safety

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,14 +1,10 @@
-# internals
-/media/
-/examples/
-/test/
-
-# dependencies
-/node_modules/
-
-#logs
-*logs/*
-
-# ide
-.vscode/*
-*.vsix
+.git
+.env
+.npmrc
+.claude/
+.github/
+test/
+scripts/
+*.log
+.nvmrc
+.gitignore

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     ".": "./src/index.js",
     "./color": "./src/color.js"
   },
+  "files": [
+    "src",
+    "README.md"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
## Summary
- Add `"files": ["src", "README.md"]` to `package.json` to explicitly whitelist published contents
- Replace `.npmignore` with comprehensive exclusions including `.git` (which was previously missing)
- Verified with `npm pack --dry-run` that only safe files (src/, README.md, LICENSE, package.json) are included in the tarball

Closes #2

## Test plan
- [x] `npm pack --dry-run` confirms only intended files are packaged (5 files, 18.4 kB)
- [ ] Verify no `.git/`, `.env`, media/, examples/, or test files appear in published package

🤖 Generated with [Claude Code](https://claude.com/claude-code)