### PR TITLE
docs: establish documentation conventions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# @stonyx/logs
+
+See [docs/index.md](../docs/index.md) for project documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+# @stonyx/logs
+
+Simplified logging for Node.js applications. Built on [chalk](https://www.npmjs.com/package/chalk), providing fully configurable, expressive console and file logging.
+
+## Documentation
+
+- [README](../README.md) -- usage examples, API reference, and configuration options
+- [Release instructions](release.md)
+
+## Overview
+
+@stonyx/logs provides:
+- Configurable log types with color-coded console output
+- File logging with optional timestamps, prefixes, and suffixes
+- Custom log type definitions via `defineType()`
+- Async file-write support with `await`
+
+> **Note:** The README currently references the upstream "Chronicle" branding. See [abofs/stonyx-logs#1](https://github.com/abofs/stonyx-logs/issues/1) for the alignment issue tracking that rename.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,3 @@
+# Release Instructions
+
+> Placeholder -- release process to be documented as part of onboarding.


### PR DESCRIPTION
## Summary
- Create `docs/index.md` as human-facing documentation entry point with brief overview and link to README
- Create `docs/release.md` as placeholder for release instructions
- Create `.claude/CLAUDE.md` as thin agent entry point referencing `docs/index.md`
- Note: README's "Chronicle" branding is tracked separately in #1

## Context
Onboarding Step 3 -- establishing consistent documentation conventions across Stonyx repos.

## Test plan
- [ ] Verify `docs/index.md` renders correctly and links work
- [ ] Verify `.claude/CLAUDE.md` link to `docs/index.md` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)