### PR TITLE
refactor: rename Chronicle references to Log

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@
 
 ---
 
-**Chronicle** is built on top of all the great work done by "Sindre Sorhus" and other collaborators of the [chalk](https://www.npmjs.com/package/chalk) project.
-This project is not directly associated with chalk other than chalk being a core dependency of **Chronicle**.
+**Log** is built on top of all the great work done by "Sindre Sorhus" and other collaborators of the [chalk](https://www.npmjs.com/package/chalk) project.
+This project is not directly associated with chalk other than chalk being a core dependency of **Log**.
 
-**IMPORTANT**: Please note that although **Chronicle** can be configured to any color through chalk, your output is subject to your terminal's color limitations.
+**IMPORTANT**: Please note that although **Log** can be configured to any color through chalk, your output is subject to your terminal's color limitations.
 
 ## Highlights
 
@@ -45,27 +45,27 @@ This project is not directly associated with chalk other than chalk being a core
 ## Install
 
 ```sh
-npm install node-chronicle
+npm install @stonyx/logs
 ```
 
 ## Usage
 
 ```js
-import Chronicle from 'node-chronicle';
+import Log from '@stonyx/logs';
 
-const chronicle = new Chronicle();
+const log = new Log();
 
-chronicle.info('Info: sample application has started');
-chronicle.warn('Warning: this is just a sample');
-chronicle.error('Error: no application logic detected', true); // logs to logs/error.log file
+log.info('Info: sample application has started');
+log.warn('Warning: this is just a sample');
+log.error('Error: no application logic detected', true); // logs to logs/error.log file
 ```
 
 Easily define your own logging mechanism and color-coding preference:
 
 ```js
-import Chronicle from 'node-chronicle';
+import Log from '@stonyx/logs';
 
-const chronicle = new Chronicle({
+const log = new Log({
   systemLogs: {
     blue: '#007cae', // indigo blue
     yellow: '#ae8f00', // bright orange
@@ -73,17 +73,17 @@ const chronicle = new Chronicle({
   },
 });
 
-chronicle.blue('Info: using custom method blue, sample application has started');
-chronicle.yellow('Warning: using custom method yellow, this is just a sample');
-chronicle.red('Error: using custom method red, no application logic detected', false);
+log.blue('Info: using custom method blue, sample application has started');
+log.yellow('Warning: using custom method yellow, this is just a sample');
+log.red('Error: using custom method red, no application logic detected', false);
 ```
 
 Customize logging options to best suit your project
 
 ```js
-import Chronicle from 'node-chronicle';
+import Log from '@stonyx/logs';
 
-const chronicle = new Chronicle({
+const log = new Log({
   logToFileByDefault: true,
   logTimestamp: true,
   path: 'custom-logs', // <project root>/custom-logs/*.log
@@ -91,7 +91,7 @@ const chronicle = new Chronicle({
   suffix: '\n=============================================================== \n',
 });
 
-chronicle.info('Info: sample application has started');
+log.info('Info: sample application has started');
 ```
 ![](https://github.com/abofs/stonyx-logs/raw/main/media/examples/custom-options.jpg)
 
@@ -99,15 +99,15 @@ chronicle.info('Info: sample application has started');
 Add additional log types extending the default options of "info", "warn", "error" and "debug"
 
 ```js
-import Chronicle from '../source/index.js';
+import Log from '@stonyx/logs';
 
-const chronicle = new Chronicle({ additionalLogs: { question: 'green' } });
+const log = new Log({ additionalLogs: { question: 'green' } });
 
 // create additional log with direct chalk configuration
-chronicle.defineType('query', chronicle.chalk().black.bgGreen);
+log.defineType('query', log.chalk().black.bgGreen);
 
-chronicle.question('What will a fully custom chalk color function look like?');
-await chronicle.query('This is what a custom chalk color setting looks like', true);
+log.question('What will a fully custom chalk color function look like?');
+await log.query('This is what a custom chalk color setting looks like', true);
 ```
 ![](https://github.com/abofs/stonyx-logs/raw/main/media/examples/additional-logs.jpg)
 
@@ -115,7 +115,7 @@ await chronicle.query('This is what a custom chalk color setting looks like', tr
 
 ### Defining Logs & Colors
 
-By default, **Chronicle** is instantiated with the following options:
+By default, **Log** is instantiated with the following options:
 
 ```js
   additionalLogs: {},
@@ -126,10 +126,10 @@ By default, **Chronicle** is instantiated with the following options:
   },
 ```
 
-You can add to a new log/color setting by passing the `additionalLogs` option to the **Chronicle** constructor. Any setting that already exists in `systemLogs` will be replaced, otherwise they will be added.
+You can add to a new log/color setting by passing the `additionalLogs` option to the **Log** constructor. Any setting that already exists in `systemLogs` will be replaced, otherwise they will be added.
  
 ```js
-  const chronicle = new Chronicle({ additionalLogs: { info: 'green', custom: 'cyan' } });
+  const log = new Log({ additionalLogs: { info: 'green', custom: 'cyan' } });
 
   // output configuration:
   {
@@ -140,13 +140,13 @@ You can add to a new log/color setting by passing the `additionalLogs` option to
   }
 ```
 
-**Chronicle** will generate convenience methods for all keys provided, with the corresponding color settings. The example above would create the following convenience methods, for logging:
+**Log** will generate convenience methods for all keys provided, with the corresponding color settings. The example above would create the following convenience methods, for logging:
 
 ```js
-  chronicle.info() // green output
-  chronicle.warn() // yellow output
-  chronicle.error() // red output
-  chronicle.custom() // cyan output
+  log.info() // green output
+  log.warn() // yellow output
+  log.error() // red output
+  log.custom() // cyan output
 ```
 
 These methods can then be called in your application with [logging parameters](#logging-parameters).
@@ -157,7 +157,7 @@ Additionally, these methods return a promise when `logToFile` is true, allowing 
 
 ```js
 async method() {
-  await chronicle.error('error message', true);
+  await log.error('error message', true);
 
   // do something after logs/error.log (default) is created
 }
@@ -165,7 +165,7 @@ async method() {
 
 ### The Debug Method
 
-**Chronicle** allows for the `chronicle.debug()` method to be overridden by a color setting. However, by default we do not define a color for debug and debug is handled differently. For console logging, all **debug** does is output the following:
+**Log** allows for the `log.debug()` method to be overridden by a color setting. However, by default we do not define a color for debug and debug is handled differently. For console logging, all **debug** does is output the following:
 
 ```js
 // For logging to console:
@@ -175,12 +175,12 @@ console.dir(content);
 JSON.stringify(content, null, 2);
 ```
 
-We believe that when wanting to output complicated objects or debug **typescript** applications, there are better methods than utilizing this **Chronicle** package. But for anyone who's fully incorporated **Chronicle** into their project, this function offers some convenience.
+We believe that when wanting to output complicated objects or debug **typescript** applications, there are better methods than utilizing this **Log** package. But for anyone who's fully incorporated **Log** into their project, this function offers some convenience.
 
 ### Logging Parameters
 
 ```js
-chronicle.error('error message', true, false); // content, logToFile, overwrite
+log.error('error message', true, false); // content, logToFile, overwrite
 ```
 
 | Parameter | Type | Default | Description |
@@ -192,10 +192,10 @@ chronicle.error('error message', true, false); // content, logToFile, overwrite
 **logToFile** will log to *<project-root>/logs* unless [configured](#configuration) differently during instantiation. <br>
 ### Configuration
 
-When instantiating **Chronicle**, you can pass an object to customize your settings. Below is the default configuration:
+When instantiating **Log**, you can pass an object to customize your settings. Below is the default configuration:
 
 ```js
-const chronicle = new Chronicle({
+const log = new Log({
   logToFileByDefault: false,
   logTimestamp: false,
   path: 'logs/',
@@ -220,26 +220,26 @@ const chronicle = new Chronicle({
 | `suffix` | **String** | *''* | Suffix string to tack on to all log messages for all log types with the exception of *debug*. |
 | `filename` | **String** | *''* | Template for log file names with variable support. Defaults to `{type}.log` when empty. See [dynamic file names](#dynamic-file-names). |
 | `additionalLogs` | **Object** | | Key value pair object containing log type to color setting for logs that will be merged with `systemLogs` |
-| `systemLogs` | **Object** | | Key value pair object containing log type to color setting for main **Chronicle** logs available in application |
+| `systemLogs` | **Object** | | Key value pair object containing log type to color setting for main **Log** logs available in application |
 
 `additionalLogs` and `systemLogs` are explained with more detail in the [defining logs and colors](#defining-logs) section.
 
 ### Advanced Configuration
 
-You may want to do more than just pick a basic color for your output. **chalk** offers a variety of different options, and can be configured via `defineType()`. **Chronicle** exposes the chalk instance via `chalk()` so that you don't have to import **chalk** directly into your project. Here is an example of how you can use this method to fully customize your log color setting:
+You may want to do more than just pick a basic color for your output. **chalk** offers a variety of different options, and can be configured via `defineType()`. **Log** exposes the chalk instance via `chalk()` so that you don't have to import **chalk** directly into your project. Here is an example of how you can use this method to fully customize your log color setting:
 
 ```js
-const chronicle = new Chronicle();
+const log = new Log();
 
-chronicle.defineType('critical', chronicle.chalk().bold.red);
-chronicle.critical('This is a critical error');
+log.defineType('critical', log.chalk().bold.red);
+log.critical('This is a critical error');
 ```
 
 Additionally, any [configuration](#configuration) that can be set during instantiation, can also be applied exclusively to any given type by passing in a third **options** parameter.
 
 ```js
 // params: type, setting, options
-chronicle.definetype('notice', '#c0c0c0', {
+log.definetype('notice', '#c0c0c0', {
   prefix: '--------------------------------------------------------------- \n',
   suffix: '\n=============================================================== \n'
 });
@@ -254,20 +254,20 @@ chronicle.definetype('notice', '#c0c0c0', {
 
 
 ```js
-const chronicle = new Chronicle();
+const log = new Log();
 
-chronicle.defineType('info', chronicle.chalk().black.bgCyan);
-chronicle.defineType('critical', chronicle.chalk().bold.red);
-chronicle.defineType('dialog', 'magentaBright');
-chronicle.definetype('notice', '#c0c0c0', {
+log.defineType('info', log.chalk().black.bgCyan);
+log.defineType('critical', log.chalk().bold.red);
+log.defineType('dialog', 'magentaBright');
+log.definetype('notice', '#c0c0c0', {
   prefix: '--------------------------------------------------------------- \n',
   suffix: '\n=============================================================== \n'
 });
 
-chronicle.info('This pre-existing log now has a cyan background and black foreground');
-chronicle.critical('This new log is bold and red');
-chronicle.dialog('This new dialog is bright magenta');
-chronicle.notice('This new log is the hex "#c0c0c0" share of gray');
+log.info('This pre-existing log now has a cyan background and black foreground');
+log.critical('This new log is bold and red');
+log.dialog('This new dialog is bright magenta');
+log.notice('This new log is the hex "#c0c0c0" share of gray');
 ```
 
 `defineType()` can also be used as an alternative to populating the `additionalLogs` setting in the constructor, as if the setting doesn't already exist, it will then be created.
@@ -289,15 +289,15 @@ The `filename` option supports template variables that are resolved at write-tim
 
 ```js
 // Per-type filename via defineType
-chronicle.defineType('error', 'red', { filename: 'error-{date}.log' });
+log.defineType('error', 'red', { filename: 'error-{date}.log' });
 // writes to: logs/error-2026-04-04.log
 
 // Per-type filename with multiple variables
-chronicle.defineType('info', 'cyan', { filename: '{type}-{hostname}-{date}.log' });
+log.defineType('info', 'cyan', { filename: '{type}-{hostname}-{date}.log' });
 // writes to: logs/info-my-server-2026-04-04.log
 
 // Global filename template via constructor
-const chronicle = new Chronicle({ filename: '{type}-{date}.log' });
+const log = new Log({ filename: '{type}-{date}.log' });
 // all types write to: logs/<type>-2026-04-04.log
 ```
 
@@ -307,9 +307,9 @@ Path traversal characters (`..`, `/`, `\`) are automatically stripped from resol
 
 ## Origin
 
-As a team of developers who are constantly working on side projects, we often litter our codebase with TODOs to refactor convenience utils such as **chronicle** into classes of their own, or projects of their own. This usually turns into internal tech debt that never gets addressed. Furthermore, we also often find ourselves going the *copy -> paste -> modify* route of previously written useful logic, which saves us time in new projects, but not as much as it would if all we had to do was run an `npm install` instead. 
+As a team of developers who are constantly working on side projects, we often litter our codebase with TODOs to refactor convenience utils such as **@stonyx/logs** into classes of their own, or projects of their own. This usually turns into internal tech debt that never gets addressed. Furthermore, we also often find ourselves going the *copy -> paste -> modify* route of previously written useful logic, which saves us time in new projects, but not as much as it would if all we had to do was run an `npm install` instead. 
 
-With that in mind, we are proud to release **chronicle** as an open source package, in hopes others will find this just as useful as we do in their own projects.  
+With that in mind, we are proud to release **@stonyx/logs** as an open source package, in hopes others will find this just as useful as we do in their own projects.  
 
 ## Maintainers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,4 +20,4 @@ Simplified logging for Node.js applications. Built on [chalk](https://www.npmjs.
 - Custom log type definitions via `defineType()`
 - Async file-write support with `await`
 
-> **Note:** The README currently references the upstream "Chronicle" branding. See [abofs/stonyx-logs#1](https://github.com/abofs/stonyx-logs/issues/1) for the alignment issue tracking that rename.
+> **Note:** The internal class is named `Log`. See [abofs/stonyx-logs#11](https://github.com/abofs/stonyx-logs/issues/11) for the rename tracking issue.

--- a/examples/additional-logs.js
+++ b/examples/additional-logs.js
@@ -1,14 +1,14 @@
 /*
  * Fully custom system logging configuration
- * instantiate chronicle with additional logs, and advanced color setting
+ * instantiate log with additional logs, and advanced color setting
  */
 
-import Chronicle from '../src/index.js';
+import Log from '../src/index.js';
 
-const chronicle = new Chronicle({ additionalLogs: { question: 'green' }});
+const log = new Log({ additionalLogs: { question: 'green' }});
 
 // create additional log with advanced direct chalk configuration
-chronicle.defineType('query', chronicle.chalk().black.bgGreen);
+log.defineType('query', log.chalk().black.bgGreen);
 
-chronicle.question('What will a fully custom chalk color function look like?');
-chronicle.query('This is what a custom chalk color setting looks like');
+log.question('What will a fully custom chalk color function look like?');
+log.query('This is what a custom chalk color setting looks like');

--- a/examples/custom-options.js
+++ b/examples/custom-options.js
@@ -1,11 +1,11 @@
 /*
  * Fully custom system logging configuration
- * instantiate chronicle with custom options
+ * instantiate log with custom options
  */
 
-import Chronicle from '../src/index.js';
+import Log from '../src/index.js';
 
-const chronicle = new Chronicle({
+const log = new Log({
   logToFileByDefault: true,
   logTimestamp: true,
   path: 'custom-logs', // purposely didn't include trailing "/" to test input sanitizer
@@ -13,6 +13,6 @@ const chronicle = new Chronicle({
   suffix: '\n=============================================================== \n',
 });
 
-chronicle.info('Info: sample application has started');
-chronicle.warn('Warning: this is just a sample');
-chronicle.error('Error: no application logic detected');
+log.info('Info: sample application has started');
+log.warn('Warning: this is just a sample');
+log.error('Error: no application logic detected');

--- a/examples/custom-system-logs.js
+++ b/examples/custom-system-logs.js
@@ -1,11 +1,11 @@
 /*
  * Fully custom system logging configuration
- * instantiate chronicle with custom system logs
+ * instantiate log with custom system logs
  */
 
-import Chronicle from '../src/index.js';
+import Log from '../src/index.js';
 
-const chronicle = new Chronicle({
+const log = new Log({
   systemLogs: {
     blue: '#007cae',
     yellow: '#ae8f00', // bright orange
@@ -13,6 +13,6 @@ const chronicle = new Chronicle({
   },
 });
 
-chronicle.blue('Info: using custom method blue, sample application has started');
-chronicle.yellow('Warning: using custom method yellow, this is just a sample');
-chronicle.red('Error: using custom method red, no application logic detected', false);
+log.blue('Info: using custom method blue, sample application has started');
+log.yellow('Warning: using custom method yellow, this is just a sample');
+log.red('Error: using custom method red, no application logic detected', false);

--- a/examples/default.js
+++ b/examples/default.js
@@ -1,16 +1,16 @@
 /*
  * Default settings (Out of the box)
- * Instantiate chronicle with default settings
+ * Instantiate log with default settings
  */
 
-import Chronicle from '../src/index.js';
+import Log from '../src/index.js';
 
-const chronicle = new Chronicle();
+const log = new Log();
 
-chronicle.info('Info: sample application has started');
-chronicle.warn('Warning: this is just a sample');
-chronicle.error('Error: no application logic detected', true); // passes true in order to log to logs/error.log file
-chronicle.debug({
+log.info('Info: sample application has started');
+log.warn('Warning: this is just a sample');
+log.error('Error: no application logic detected', true); // passes true in order to log to logs/error.log file
+log.debug({
   foo: 'bar',
   x: 6,
 }, true);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "log",
     "logging",
     "color-coding",
-    "chronicle",
+    "stonyx",
     "history",
     "documentation",
     "document",

--- a/src/color.js
+++ b/src/color.js
@@ -22,7 +22,7 @@ export default class Color {
   // retrieves chalk color function, and fully validates output
   settingToChalkColorFunction(setting) {
     const errorMessage = 'Invalid chalk color function.'
-      + 'For help with color settings, see https://github.com/abofs/chronicle#defining-logs--colors';
+      + 'For help with color settings, see https://github.com/abofs/stonyx-logs#defining-logs--colors';
 
     switch (typeof setting) {
     case 'string':

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const defaultOptions = {
 // used to sanitize defineType() options input
 const optionKeys = Object.keys(defaultOptions);
 
-export default class Chronicle {
+export default class Log {
   constructor(options = defaultOptions) {
     options = {
       ...defaultOptions,
@@ -48,7 +48,7 @@ export default class Chronicle {
     }
   }
 
-  // records setting and options for log type, and crates convenience method ie: chronicle.info()
+  // records setting and options for log type, and creates convenience method ie: log.info()
   defineType(type, setting, options = null) {
     this.color.setLogColor(type, setting);
 
@@ -61,7 +61,7 @@ export default class Chronicle {
     for (let option of Object.keys(options)) {
       if (!optionKeys.includes(option)) {
         throw `${option} is not a valid configuration object.`
-        + '\n For a list of available options, see https://github.com/abofs/chronicle#configuration';
+        + '\n For a list of available options, see https://github.com/abofs/stonyx-logs#configuration';
       }
 
       // sanitize path input

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,6 +1,6 @@
 import Qunit from 'qunit';
 import { promises as fsp } from 'fs';
-import Chronicle from '../src/index.js';
+import Log from '../src/index.js';
 
 const { module, test } = Qunit;
 
@@ -22,16 +22,16 @@ async function targetExists(target) {
   return targetExists;
 }
 
-module('[Integration] Chronicle Tests', () => {
+module('[Integration] Log Tests', () => {
   test('Convenience methods for systemLogs are successfully created', assert => {
-    const chronicle = new Chronicle({
+    const log = new Log({
       systemLogs: {
         a: 'white',
         b: 'blue',
         c: 'red',
       },
     });
-    const { a, b, c, info, warn, error } = chronicle;
+    const { a, b, c, info, warn, error } = log;
 
     assert.deepEqual(
       [typeof a, typeof b, typeof c, info, warn, error],
@@ -41,14 +41,14 @@ module('[Integration] Chronicle Tests', () => {
   });
 
   test('Convenience methods for additionalLogs are successfully created', assert => {
-    const chronicle = new Chronicle({
+    const log = new Log({
       additionalLogs: {
         a: 'white',
         b: 'blue',
         error: 'red',
       },
     });
-    const { a, b, info, warn, error } = chronicle;
+    const { a, b, info, warn, error } = log;
 
     assert.deepEqual(
       [typeof a, typeof b, typeof info, typeof warn, typeof error],
@@ -58,14 +58,14 @@ module('[Integration] Chronicle Tests', () => {
   });
 
   test('Debug method is successfully created', assert => {
-    const chronicle = new Chronicle();
+    const log = new Log();
 
-    assert.equal(typeof chronicle.debug, 'function', 'debug method exists');
+    assert.equal(typeof log.debug, 'function', 'debug method exists');
   });
 
   test('Log creation respects the default logToFileByDefault as false', async assert => {
-    const chronicle = new Chronicle({ systemLogs: { test: 'green' }});
-    const { path } = chronicle.options;
+    const log = new Log({ systemLogs: { test: 'green' }});
+    const { path } = log.options;
 
     let logDirExists = await targetExists(path);
 
@@ -74,12 +74,12 @@ module('[Integration] Chronicle Tests', () => {
       await removeDirectory(path, assert);
     }
 
-    await chronicle.test('log test');
+    await log.test('log test');
     logDirExists = await targetExists(path);
 
     assert.notOk(logDirExists, 'Log directory does not exist');
 
-    await chronicle.test('log to file test', true);
+    await log.test('log to file test', true);
     logDirExists = await targetExists(path);
     const logFileExists = await targetExists(`${path}test.log`);
 
@@ -90,11 +90,11 @@ module('[Integration] Chronicle Tests', () => {
   });
 
   test('Log creation respects the configured logToFileByDefault setting as true', async assert => {
-    const chronicle = new Chronicle({
+    const log = new Log({
       logToFileByDefault: true,
       systemLogs: { test: 'green' },
     });
-    const { path } = chronicle.options;
+    const { path } = log.options;
 
     let logDirExists = await targetExists(path);
 
@@ -103,7 +103,7 @@ module('[Integration] Chronicle Tests', () => {
       await removeDirectory(path, assert);
     }
 
-    await chronicle.test('log to file test');
+    await log.test('log to file test');
     logDirExists = await targetExists(path);
     const logFileExists = await targetExists(`${path}test.log`);
 
@@ -112,22 +112,22 @@ module('[Integration] Chronicle Tests', () => {
 
     await removeDirectory(path, assert); // cleanup directory
 
-    await chronicle.test('log to file test', false);
+    await log.test('log to file test', false);
     logDirExists = await targetExists(path);
 
     assert.notOk(logDirExists, 'log directory does not exists');
   });
 
   test('Log creation respects the configured path setting', async assert => {
-    const chronicle = new Chronicle({
+    const log = new Log({
       path: 'test-logs',
       systemLogs: { test: 'green' },
     });
-    const { path } = chronicle.options;
+    const { path } = log.options;
 
     assert.ok(path.includes('test-logs'), 'configured directory is correct');
 
-    await chronicle.test('log to file test', true);
+    await log.test('log to file test', true);
     const logDirExists = await targetExists(path);
     const logFileExists = await targetExists(`${path}test.log`);
 
@@ -138,25 +138,25 @@ module('[Integration] Chronicle Tests', () => {
   });
 
   test('Log creation respects type specific options set via defineType', async assert => {
-    const chronicle = new Chronicle({ systemLogs: { foo: 'green' }});
-    const { path } = chronicle.options;
-    chronicle.defineType('bar', 'yellow', {
+    const log = new Log({ systemLogs: { foo: 'green' }});
+    const { path } = log.options;
+    log.defineType('bar', 'yellow', {
       logToFileByDefault: true,
       logTimestamp: true,
       path: 'test-logs',
       prefix: '--------------------------------------------------------------- \n',
       suffix: '\n=============================================================== \n',
     });
-    const barPath = chronicle.typeOptions.bar.path;
+    const barPath = log.typeOptions.bar.path;
 
-    await chronicle.foo('log with no prefix and suffix, and do not create logs');
+    await log.foo('log with no prefix and suffix, and do not create logs');
     let logDirExists = await targetExists(path);
     let barLogDirExists = await targetExists(barPath);
 
     assert.notOk(logDirExists, 'log directory does not exist');
     assert.notOk(barLogDirExists, 'defineType log directory does not exist');
 
-    await chronicle.bar('log with timestamp, prefix, suffix, and create custom logs');
+    await log.bar('log with timestamp, prefix, suffix, and create custom logs');
     logDirExists = await targetExists(path);
     barLogDirExists = await targetExists(barPath);
     const logFileExists = await targetExists(`${barPath}bar.log`);
@@ -170,10 +170,10 @@ module('[Integration] Chronicle Tests', () => {
 
   test('App crashes with descriptive error if user passes a non-object param to for options', async assert => {
     assert.expect(1); // expect assertion to happen in catch block
-    const chronicle = new Chronicle({ systemLogs: { test: 'green' }});
+    const log = new Log({ systemLogs: { test: 'green' }});
 
     try {
-      chronicle.defineType('test', 'yellow', true);
+      log.defineType('test', 'yellow', true);
     } catch (error) {
       assert.equal(error, 'The options param must be an object.');
     }
@@ -181,10 +181,10 @@ module('[Integration] Chronicle Tests', () => {
 
   test('App crashes with descriptive error when user uses defineType with bad options', async assert => {
     assert.expect(2); // expect assertions to happen in catch block
-    const chronicle = new Chronicle({ systemLogs: { test: 'green' }});
+    const log = new Log({ systemLogs: { test: 'green' }});
 
     try {
-      chronicle.defineType('test', 'yellow', {
+      log.defineType('test', 'yellow', {
         invalidOption1: true,
         invalidOption2: true,
       });

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,25 +1,25 @@
 import Qunit from 'qunit';
-import Chronicle from '../src/index.js';
+import Log from '../src/index.js';
 import { fileURLToPath } from 'url';
 import projectPath from 'path';
 
 const { module, test } = Qunit;
 
-module('[Unit] Chronicle Tests', function() {
+module('[Unit] Log Tests', function() {
     test('Path is sanitized correctly', function(assert) {
-      const chronicle = new Chronicle({ path: 'test' });
+      const log = new Log({ path: 'test' });
       const expectedPath = `${projectPath.dirname(fileURLToPath(import.meta.url))}/`;
   
-      assert.equal(chronicle.options.path, expectedPath);
+      assert.equal(log.options.path, expectedPath);
     });
 
     test('Chalk advance settings can be configured', function(assert) {
-        const chronicle = new Chronicle();
-        const { settingToChalkColorFunction } = chronicle.color;
+        const log = new Log();
+        const { settingToChalkColorFunction } = log.color;
 
-        const chalkAdvanced1 = chronicle.chalk().blue.bgRed.bold;
-        const chalkAdvanced2 = chronicle.chalk().bold.red;
-        const chalkAdvanced3 = chronicle.chalk().bgCyan.white;
+        const chalkAdvanced1 = log.chalk().blue.bgRed.bold;
+        const chalkAdvanced2 = log.chalk().bold.red;
+        const chalkAdvanced3 = log.chalk().bgCyan.white;
         const chalkColors = [];
         
         try {
@@ -47,18 +47,18 @@ module('[Unit] Chronicle Tests', function() {
     });
 
     test('Log colors are correctly set', function(assert) {
-        const chronicle = new Chronicle({ systemLogs: {} });
+        const log = new Log({ systemLogs: {} });
 
         try {
-            chronicle.color.setLogColor('test1', 'red');
-            chronicle.color.setLogColor('test2', 'white');
-            chronicle.color.setLogColor('test3', 'blue');
+            log.color.setLogColor('test1', 'red');
+            log.color.setLogColor('test2', 'white');
+            log.color.setLogColor('test3', 'blue');
         } catch { error => {
             assert.throws(error);
         }}
 
         const expectedKeys = ['test1', 'test2', 'test3']
 
-        assert.deepEqual(Object.keys(chronicle.color.types), expectedKeys, 'configured color keys');
+        assert.deepEqual(Object.keys(log.color.types), expectedKeys, 'configured color keys');
     });
 });

--- a/test/unit/filename-test.js
+++ b/test/unit/filename-test.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import Chronicle from '../../src/index.js';
+import Log from '../../src/index.js';
 import { hostname } from 'os';
 
 const { module, test } = QUnit;
@@ -21,83 +21,83 @@ module('[Unit] Dynamic filenames', function (hooks) {
 
   module('resolveFilename', function () {
     test('returns {type}.log when template is empty', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      assert.strictEqual(chronicle.resolveFilename('', 'error'), 'error.log');
-      assert.strictEqual(chronicle.resolveFilename('', 'info'), 'info.log');
+      assert.strictEqual(log.resolveFilename('', 'error'), 'error.log');
+      assert.strictEqual(log.resolveFilename('', 'info'), 'info.log');
     });
 
     test('returns {type}.log when template is undefined', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      assert.strictEqual(chronicle.resolveFilename(undefined, 'warn'), 'warn.log');
+      assert.strictEqual(log.resolveFilename(undefined, 'warn'), 'warn.log');
     });
 
     test('resolves {type} variable', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      assert.strictEqual(chronicle.resolveFilename('{type}-app.log', 'error'), 'error-app.log');
+      assert.strictEqual(log.resolveFilename('{type}-app.log', 'error'), 'error-app.log');
     });
 
     test('resolves {date} to YYYY-MM-DD format', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
       const now = new Date();
       const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
-      const result = chronicle.resolveFilename('{date}.log', 'info');
+      const result = log.resolveFilename('{date}.log', 'info');
       assert.strictEqual(result, `${expected}.log`);
     });
 
     test('resolves {pid} to current process ID', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      const result = chronicle.resolveFilename('app-{pid}.log', 'info');
+      const result = log.resolveFilename('app-{pid}.log', 'info');
       assert.strictEqual(result, `app-${process.pid}.log`);
     });
 
     test('resolves {hostname} to machine hostname', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      const result = chronicle.resolveFilename('app-{hostname}.log', 'info');
+      const result = log.resolveFilename('app-{hostname}.log', 'info');
       assert.strictEqual(result, `app-${hostname()}.log`);
     });
 
     test('resolves multiple variables in a single template', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
       const now = new Date();
       const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
-      const result = chronicle.resolveFilename('{type}-{date}.log', 'error');
+      const result = log.resolveFilename('{type}-{date}.log', 'error');
       assert.strictEqual(result, `error-${dateStr}.log`);
     });
 
     test('leaves unknown variables unresolved', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      const result = chronicle.resolveFilename('{type}-{unknown}.log', 'info');
+      const result = log.resolveFilename('{type}-{unknown}.log', 'info');
       assert.strictEqual(result, 'info-{unknown}.log');
     });
 
     test('strips path traversal sequences', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      const result = chronicle.resolveFilename('../../etc/passwd', 'info');
+      const result = log.resolveFilename('../../etc/passwd', 'info');
       assert.ok(!result.includes('..'), 'no double-dot sequences');
       assert.ok(!result.includes('/'), 'no forward slashes');
     });
 
     test('strips directory separators from resolved output', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      const result = chronicle.resolveFilename('sub/dir\\file.log', 'info');
+      const result = log.resolveFilename('sub/dir\\file.log', 'info');
       assert.ok(!result.includes('/'), 'no forward slashes');
       assert.ok(!result.includes('\\'), 'no backslashes');
     });
 
     test('handles template with no variables', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      assert.strictEqual(chronicle.resolveFilename('static-name.log', 'info'), 'static-name.log');
+      assert.strictEqual(log.resolveFilename('static-name.log', 'info'), 'static-name.log');
     });
   });
 
@@ -105,31 +105,31 @@ module('[Unit] Dynamic filenames', function (hooks) {
 
   module('defineType with filename', function () {
     test('accepts filename option without throwing', function (assert) {
-      const chronicle = new Chronicle({ systemLogs: { test: 'red' } });
+      const log = new Log({ systemLogs: { test: 'red' } });
 
-      chronicle.defineType('test', 'red', { filename: 'test-{date}.log' });
-      assert.strictEqual(chronicle.typeOptions.test.filename, 'test-{date}.log', 'filename option stored');
+      log.defineType('test', 'red', { filename: 'test-{date}.log' });
+      assert.strictEqual(log.typeOptions.test.filename, 'test-{date}.log', 'filename option stored');
     });
 
     test('getOptionForType returns filename when set', function (assert) {
-      const chronicle = new Chronicle({ systemLogs: { test: 'red' } });
-      chronicle.defineType('test', 'red', { filename: 'custom-{type}.log' });
+      const log = new Log({ systemLogs: { test: 'red' } });
+      log.defineType('test', 'red', { filename: 'custom-{type}.log' });
 
-      const result = chronicle.getOptionForType('test', 'filename');
+      const result = log.getOptionForType('test', 'filename');
       assert.strictEqual(result, 'custom-{type}.log', 'returns type-specific filename');
     });
 
     test('getOptionForType falls back to global filename', function (assert) {
-      const chronicle = new Chronicle({ filename: 'global-{type}.log' });
+      const log = new Log({ filename: 'global-{type}.log' });
 
-      const result = chronicle.getOptionForType('info', 'filename');
+      const result = log.getOptionForType('info', 'filename');
       assert.strictEqual(result, 'global-{type}.log', 'falls back to global filename');
     });
 
     test('getOptionForType returns empty string when no filename set', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      const result = chronicle.getOptionForType('info', 'filename');
+      const result = log.getOptionForType('info', 'filename');
       assert.strictEqual(result, '', 'returns empty string default');
     });
   });
@@ -138,18 +138,18 @@ module('[Unit] Dynamic filenames', function (hooks) {
 
   module('writeToFile uses resolved filename', function () {
     test('writeToFile calls resolveFilename with type-specific template', function (assert) {
-      const chronicle = new Chronicle({ systemLogs: { test: 'red' } });
-      chronicle.defineType('test', 'red', { filename: '{type}-{date}.log' });
+      const log = new Log({ systemLogs: { test: 'red' } });
+      log.defineType('test', 'red', { filename: '{type}-{date}.log' });
 
-      const resolveSpy = sinon.spy(chronicle, 'resolveFilename');
-      const validateStub = sinon.stub(chronicle, 'validateFileAndDirectory').resolves();
+      const resolveSpy = sinon.spy(log, 'resolveFilename');
+      const validateStub = sinon.stub(log, 'validateFileAndDirectory').resolves();
 
       // stub fsp.writeFile to prevent actual file I/O
       const writeFileStub = sinon.stub().resolves();
       const appendFileStub = sinon.stub().resolves();
 
       // we need to call writeToFile and check that resolveFilename was called
-      return chronicle.writeToFile('test', 'content', true).then(() => {
+      return log.writeToFile('test', 'content', true).then(() => {
         assert.ok(resolveSpy.calledOnce, 'resolveFilename called');
         assert.strictEqual(resolveSpy.firstCall.args[0], '{type}-{date}.log', 'passes filename template');
         assert.strictEqual(resolveSpy.firstCall.args[1], 'test', 'passes type');
@@ -160,12 +160,12 @@ module('[Unit] Dynamic filenames', function (hooks) {
     });
 
     test('writeToFile defaults to {type}.log when no filename configured', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      const resolveSpy = sinon.spy(chronicle, 'resolveFilename');
-      sinon.stub(chronicle, 'validateFileAndDirectory').resolves();
+      const resolveSpy = sinon.spy(log, 'resolveFilename');
+      sinon.stub(log, 'validateFileAndDirectory').resolves();
 
-      return chronicle.writeToFile('info', 'content', true).then(() => {
+      return log.writeToFile('info', 'content', true).then(() => {
         const result = resolveSpy.returnValues[0];
         assert.strictEqual(result, 'info.log', 'resolved to default filename');
       }).catch(() => {

--- a/test/unit/log-test.js
+++ b/test/unit/log-test.js
@@ -1,10 +1,10 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import Chronicle from '../../src/index.js';
+import Log from '../../src/index.js';
 
 const { module, test } = QUnit;
 
-module('[Unit] Chronicle', function (hooks) {
+module('[Unit] Log', function (hooks) {
   let consoleLogStub;
   let consoleDirStub;
 
@@ -21,70 +21,70 @@ module('[Unit] Chronicle', function (hooks) {
 
   module('initialization', function () {
     test('creates instance with default options', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      assert.ok(chronicle instanceof Chronicle, 'is a Chronicle instance');
-      assert.strictEqual(chronicle.options.logToFileByDefault, false, 'logToFileByDefault defaults to false');
-      assert.strictEqual(chronicle.options.logTimestamp, false, 'logTimestamp defaults to false');
-      assert.strictEqual(chronicle.options.prefix, '', 'prefix defaults to empty string');
-      assert.strictEqual(chronicle.options.suffix, '', 'suffix defaults to empty string');
+      assert.ok(log instanceof Log, 'is a Log instance');
+      assert.strictEqual(log.options.logToFileByDefault, false, 'logToFileByDefault defaults to false');
+      assert.strictEqual(log.options.logTimestamp, false, 'logTimestamp defaults to false');
+      assert.strictEqual(log.options.prefix, '', 'prefix defaults to empty string');
+      assert.strictEqual(log.options.suffix, '', 'suffix defaults to empty string');
     });
 
     test('creates default system log methods (info, warn, error)', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      assert.strictEqual(typeof chronicle.info, 'function', 'info method exists');
-      assert.strictEqual(typeof chronicle.warn, 'function', 'warn method exists');
-      assert.strictEqual(typeof chronicle.error, 'function', 'error method exists');
+      assert.strictEqual(typeof log.info, 'function', 'info method exists');
+      assert.strictEqual(typeof log.warn, 'function', 'warn method exists');
+      assert.strictEqual(typeof log.error, 'function', 'error method exists');
     });
 
     test('creates debug method', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
 
-      assert.strictEqual(typeof chronicle.debug, 'function', 'debug method exists');
+      assert.strictEqual(typeof log.debug, 'function', 'debug method exists');
     });
 
     test('merges user options with defaults', function (assert) {
-      const chronicle = new Chronicle({
+      const log = new Log({
         logTimestamp: true,
         prefix: '[APP] ',
       });
 
-      assert.strictEqual(chronicle.options.logTimestamp, true, 'logTimestamp overridden');
-      assert.strictEqual(chronicle.options.prefix, '[APP] ', 'prefix overridden');
-      assert.strictEqual(chronicle.options.logToFileByDefault, false, 'logToFileByDefault retains default');
+      assert.strictEqual(log.options.logTimestamp, true, 'logTimestamp overridden');
+      assert.strictEqual(log.options.prefix, '[APP] ', 'prefix overridden');
+      assert.strictEqual(log.options.logToFileByDefault, false, 'logToFileByDefault retains default');
     });
 
     test('creates convenience methods for custom systemLogs', function (assert) {
-      const chronicle = new Chronicle({
+      const log = new Log({
         systemLogs: {
           success: 'green',
           trace: 'gray',
         },
       });
 
-      assert.strictEqual(typeof chronicle.success, 'function', 'success method created');
-      assert.strictEqual(typeof chronicle.trace, 'function', 'trace method created');
-      assert.strictEqual(chronicle.info, undefined, 'default info not created when systemLogs overridden');
+      assert.strictEqual(typeof log.success, 'function', 'success method created');
+      assert.strictEqual(typeof log.trace, 'function', 'trace method created');
+      assert.strictEqual(log.info, undefined, 'default info not created when systemLogs overridden');
     });
 
     test('creates convenience methods for additionalLogs merged with systemLogs', function (assert) {
-      const chronicle = new Chronicle({
+      const log = new Log({
         additionalLogs: {
           custom: 'green',
         },
       });
 
-      assert.strictEqual(typeof chronicle.custom, 'function', 'custom method created');
-      assert.strictEqual(typeof chronicle.info, 'function', 'info still exists from default systemLogs');
-      assert.strictEqual(typeof chronicle.warn, 'function', 'warn still exists from default systemLogs');
-      assert.strictEqual(typeof chronicle.error, 'function', 'error still exists from default systemLogs');
+      assert.strictEqual(typeof log.custom, 'function', 'custom method created');
+      assert.strictEqual(typeof log.info, 'function', 'info still exists from default systemLogs');
+      assert.strictEqual(typeof log.warn, 'function', 'warn still exists from default systemLogs');
+      assert.strictEqual(typeof log.error, 'function', 'error still exists from default systemLogs');
     });
 
     test('sanitizes path to include trailing slash', function (assert) {
-      const chronicle = new Chronicle({ path: 'test-output' });
+      const log = new Log({ path: 'test-output' });
 
-      assert.ok(chronicle.options.path.endsWith('/'), 'path ends with /');
+      assert.ok(log.options.path.endsWith('/'), 'path ends with /');
     });
   });
 
@@ -92,8 +92,8 @@ module('[Unit] Chronicle', function (hooks) {
 
   module('log methods', function () {
     test('info logs to console', function (assert) {
-      const chronicle = new Chronicle();
-      chronicle.info('hello world');
+      const log = new Log();
+      log.info('hello world');
 
       assert.ok(consoleLogStub.calledOnce, 'console.log called once');
       const loggedMessage = consoleLogStub.firstCall.args[0];
@@ -101,8 +101,8 @@ module('[Unit] Chronicle', function (hooks) {
     });
 
     test('warn logs to console', function (assert) {
-      const chronicle = new Chronicle();
-      chronicle.warn('be careful');
+      const log = new Log();
+      log.warn('be careful');
 
       assert.ok(consoleLogStub.calledOnce, 'console.log called once');
       const loggedMessage = consoleLogStub.firstCall.args[0];
@@ -110,8 +110,8 @@ module('[Unit] Chronicle', function (hooks) {
     });
 
     test('error logs to console', function (assert) {
-      const chronicle = new Chronicle();
-      chronicle.error('something broke');
+      const log = new Log();
+      log.error('something broke');
 
       assert.ok(consoleLogStub.calledOnce, 'console.log called once');
       const loggedMessage = consoleLogStub.firstCall.args[0];
@@ -119,9 +119,9 @@ module('[Unit] Chronicle', function (hooks) {
     });
 
     test('debug uses console.dir with depth 6', function (assert) {
-      const chronicle = new Chronicle();
+      const log = new Log();
       const data = { foo: 'bar' };
-      chronicle.debug(data);
+      log.debug(data);
 
       assert.ok(consoleDirStub.calledOnce, 'console.dir called once');
       assert.deepEqual(consoleDirStub.firstCall.args[0], data, 'passes content to console.dir');
@@ -129,16 +129,16 @@ module('[Unit] Chronicle', function (hooks) {
     });
 
     test('log does not write to file when logToFile is false', function (assert) {
-      const chronicle = new Chronicle();
-      const writeStub = sinon.stub(chronicle, 'writeToFile');
-      chronicle.info('no file');
+      const log = new Log();
+      const writeStub = sinon.stub(log, 'writeToFile');
+      log.info('no file');
 
       assert.ok(writeStub.notCalled, 'writeToFile not called');
     });
 
     test('log includes prefix when configured', function (assert) {
-      const chronicle = new Chronicle({ prefix: '[PREFIX] ' });
-      chronicle.info('test message');
+      const log = new Log({ prefix: '[PREFIX] ' });
+      log.info('test message');
 
       const loggedMessage = consoleLogStub.firstCall.args[0];
       assert.ok(loggedMessage.includes('[PREFIX]'), 'prefix appears in output');
@@ -146,8 +146,8 @@ module('[Unit] Chronicle', function (hooks) {
     });
 
     test('log includes suffix when configured', function (assert) {
-      const chronicle = new Chronicle({ suffix: ' [END]' });
-      chronicle.info('test message');
+      const log = new Log({ suffix: ' [END]' });
+      log.info('test message');
 
       const loggedMessage = consoleLogStub.firstCall.args[0];
       assert.ok(loggedMessage.includes('[END]'), 'suffix appears in output');
@@ -158,47 +158,47 @@ module('[Unit] Chronicle', function (hooks) {
 
   module('defineType', function () {
     test('creates a new convenience method', function (assert) {
-      const chronicle = new Chronicle({ systemLogs: {} });
-      assert.strictEqual(chronicle.custom, undefined, 'custom method does not exist initially');
+      const log = new Log({ systemLogs: {} });
+      assert.strictEqual(log.custom, undefined, 'custom method does not exist initially');
 
-      chronicle.defineType('custom', 'green');
-      assert.strictEqual(typeof chronicle.custom, 'function', 'custom method created');
+      log.defineType('custom', 'green');
+      assert.strictEqual(typeof log.custom, 'function', 'custom method created');
     });
 
     test('does not overwrite existing convenience method', function (assert) {
-      const chronicle = new Chronicle({ systemLogs: { test: 'red' } });
-      const originalMethod = chronicle.test;
+      const log = new Log({ systemLogs: { test: 'red' } });
+      const originalMethod = log.test;
 
-      chronicle.defineType('test', 'blue');
-      assert.strictEqual(chronicle.test, originalMethod, 'method reference unchanged');
+      log.defineType('test', 'blue');
+      assert.strictEqual(log.test, originalMethod, 'method reference unchanged');
     });
 
     test('stores type-specific options', function (assert) {
-      const chronicle = new Chronicle({ systemLogs: { test: 'red' } });
-      chronicle.defineType('test', 'red', {
+      const log = new Log({ systemLogs: { test: 'red' } });
+      log.defineType('test', 'red', {
         logToFileByDefault: true,
         prefix: '>> ',
       });
 
-      assert.strictEqual(chronicle.typeOptions.test.logToFileByDefault, true, 'type option stored');
-      assert.strictEqual(chronicle.typeOptions.test.prefix, '>> ', 'type prefix stored');
+      assert.strictEqual(log.typeOptions.test.logToFileByDefault, true, 'type option stored');
+      assert.strictEqual(log.typeOptions.test.prefix, '>> ', 'type prefix stored');
     });
 
     test('throws on non-object options param', function (assert) {
-      const chronicle = new Chronicle({ systemLogs: { test: 'red' } });
+      const log = new Log({ systemLogs: { test: 'red' } });
 
       assert.throws(
-        () => chronicle.defineType('test', 'red', 'bad'),
+        () => log.defineType('test', 'red', 'bad'),
         /The options param must be an object/,
         'throws descriptive error',
       );
     });
 
     test('throws on invalid option keys', function (assert) {
-      const chronicle = new Chronicle({ systemLogs: { test: 'red' } });
+      const log = new Log({ systemLogs: { test: 'red' } });
 
       assert.throws(
-        () => chronicle.defineType('test', 'red', { invalidOption: true }),
+        () => log.defineType('test', 'red', { invalidOption: true }),
         /invalidOption is not a valid configuration object/,
         'throws with invalid option name',
       );
@@ -209,17 +209,17 @@ module('[Unit] Chronicle', function (hooks) {
 
   module('getOptionForType', function () {
     test('returns global option when no type-specific option set', function (assert) {
-      const chronicle = new Chronicle({ prefix: '[GLOBAL] ' });
+      const log = new Log({ prefix: '[GLOBAL] ' });
 
-      const result = chronicle.getOptionForType('info', 'prefix');
+      const result = log.getOptionForType('info', 'prefix');
       assert.strictEqual(result, '[GLOBAL] ', 'falls back to global option');
     });
 
     test('returns type-specific option when set', function (assert) {
-      const chronicle = new Chronicle({ systemLogs: { test: 'red' } });
-      chronicle.defineType('test', 'red', { prefix: '[TYPE] ' });
+      const log = new Log({ systemLogs: { test: 'red' } });
+      log.defineType('test', 'red', { prefix: '[TYPE] ' });
 
-      const result = chronicle.getOptionForType('test', 'prefix');
+      const result = log.getOptionForType('test', 'prefix');
       assert.strictEqual(result, '[TYPE] ', 'uses type-specific option');
     });
   });
@@ -228,8 +228,8 @@ module('[Unit] Chronicle', function (hooks) {
 
   module('chalk', function () {
     test('returns chalk instance', function (assert) {
-      const chronicle = new Chronicle();
-      const chalkInstance = chronicle.chalk();
+      const log = new Log();
+      const chalkInstance = log.chalk();
 
       assert.ok(chalkInstance, 'chalk instance returned');
       assert.strictEqual(typeof chalkInstance.red, 'function', 'chalk has color methods');


### PR DESCRIPTION
## Summary
- Renamed all `Chronicle`/`chronicle` identifiers to `Log`/`log` across 13 files (~194 replacements): class name, variable names, comments, documentation, examples, and tests
- Renamed `test/unit/chronicle-test.js` to `test/unit/log-test.js`
- Updated stale upstream URLs (e.g., `github.com/abofs/chronicle` to `github.com/abofs/stonyx-logs`) and package references (e.g., `node-chronicle` to `@stonyx/logs`)
- Replaced the `"chronicle"` keyword in `package.json` with `"stonyx"`

Fixes abofs/stonyx-logs#11

## Test plan
- [x] `pnpm test` -- all 53 unit tests pass
- [x] `grep -ri "chronicle"` returns zero results (excluding node_modules and .git)
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)