### PR TITLE
feat: add daily security audit workflow

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,13 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    uses: abofs/stonyx-workflows/.github/workflows/security-audit.yml@main


### PR DESCRIPTION
## Summary
- Adds a `security-audit.yml` caller workflow that invokes the shared reusable workflow from `stonyx-workflows`
- Runs daily at 08:00 UTC via cron schedule, plus manual trigger via `workflow_dispatch`
- Report-only, non-blocking — audit findings are visible in the Actions tab but never fail the build

Part of stonyx#12.

## Test plan
- [ ] Merge the shared workflow PR in stonyx-workflows first (abofs/stonyx-workflows#8)
- [ ] Merge this PR, then trigger a manual run via the Actions tab to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)