### PR TITLE
feat: TypeScript migration with strict mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 # ide
 .vscode/*
 *.vsix
+
+# build output
+dist/
+dist-test/
+.ts-migration-log.json

--- a/package.json
+++ b/package.json
@@ -3,13 +3,20 @@
   "version": "1.0.1-beta.11",
   "description": "Simplified logging for node applications",
   "type": "module",
-  "main": "src/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
-    ".": "./src/index.js",
-    "./color": "./src/color.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./color": {
+      "types": "./dist/color.d.ts",
+      "default": "./dist/color.js"
+    }
   },
   "files": [
-    "src",
+    "dist",
     "README.md"
   ],
   "publishConfig": {
@@ -17,7 +24,9 @@
     "provenance": true
   },
   "scripts": {
-    "test": "qunit 'test/unit/**/*-test.js'",
+    "build": "tsc",
+    "build:test": "tsc -p tsconfig.test.json",
+    "test": "pnpm build && pnpm build:test && qunit 'dist-test/test/unit/**/*-test.js'",
     "lint": "eslint . --fix"
   },
   "repository": {
@@ -47,9 +56,13 @@
     "chalk": "^5.3.0"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
+    "@types/qunit": "^2.19.13",
+    "@types/sinon": "^21.0.1",
     "eslint": "^8.27.0",
     "eslint-plugin-node": "^11.1.0",
     "qunit": "^2.19.3",
-    "sinon": "^17.0.0"
+    "sinon": "^17.0.0",
+    "typescript": "^5.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,15 @@ importers:
         specifier: ^5.3.0
         version: 5.6.2
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
+      '@types/qunit':
+        specifier: ^2.19.13
+        version: 2.19.13
+      '@types/sinon':
+        specifier: ^21.0.1
+        version: 21.0.1
       eslint:
         specifier: ^8.27.0
         version: 8.57.1
@@ -24,6 +33,9 @@ importers:
       sinon:
         specifier: ^17.0.0
         version: 17.0.2
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
 
 packages:
 
@@ -84,6 +96,18 @@ packages:
     deprecated: |-
       Deprecated: no longer maintained and no longer used by Sinon packages. See
         https://github.com/sinonjs/nise/issues/243 for replacement details.
+
+  '@types/node@25.5.2':
+    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
+
+  '@types/qunit@2.19.13':
+    resolution: {integrity: sha512-N4xp3v4s7f0jb2Oij6+6xw5QhH7/IgHCoGIFLCWtbEWoPkGYp8Te4mIwIP21qaurr6ed5JiPMiy2/ZoiGPkLIw==}
+
+  '@types/sinon@21.0.1':
+    resolution: {integrity: sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -504,6 +528,14 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -586,6 +618,18 @@ snapshots:
       type-detect: 4.1.0
 
   '@sinonjs/text-encoding@0.7.3': {}
+
+  '@types/node@25.5.2':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/qunit@2.19.13': {}
+
+  '@types/sinon@21.0.1':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -993,6 +1037,10 @@ snapshots:
   type-detect@4.1.0: {}
 
   type-fest@0.20.2: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,32 +1,34 @@
 import chalk from 'chalk';
 
-export default class Color {
-  constructor() {
-    this.types = [];
-  }
+export type ChalkColorFn = (text: string) => string;
+export type ColorSetting = string | ChalkColorFn;
 
-  // retrieves configured color function for log type
-  getLogColor(type) {
+export default class Color {
+  types: Record<string, ChalkColorFn> = {};
+
+  getLogColor(type: string): ChalkColorFn {
     return this.types[type];
   }
 
-  getChalkInstance() {
+  getChalkInstance(): typeof chalk {
     return chalk;
   }
 
-  setLogColor(type, setting) {
+  setLogColor(type: string, setting: ColorSetting): void {
     const chalkColorFunction = this.settingToChalkColorFunction(setting);
     this.types[type] = chalkColorFunction;
   }
 
   // retrieves chalk color function, and fully validates output
-  settingToChalkColorFunction(setting) {
+  settingToChalkColorFunction(setting: ColorSetting): ChalkColorFn {
     const errorMessage = 'Invalid chalk color function.'
       + 'For help with color settings, see https://github.com/abofs/stonyx-logs#defining-logs--colors';
 
     switch (typeof setting) {
     case 'string':
-      const chalkColorFunction = (setting[0] === '#') ? chalk.hex(setting) : chalk[setting];
+      const chalkColorFunction = (setting[0] === '#')
+        ? chalk.hex(setting)
+        : (chalk as unknown as Record<string, unknown>)[setting] as ChalkColorFn | undefined;
       if (!chalkColorFunction
           || typeof chalkColorFunction !== 'function'
           || typeof chalkColorFunction('') !== 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,26 @@ import { mkdirSync, promises as fsp } from 'fs';
 import { fileURLToPath } from 'url';
 import { hostname } from 'os';
 import projectPath from 'path';
-import Color from './color.js';
+import Color, { type ColorSetting, type ChalkColorFn } from './color.js';
 
-const defaultOptions = {
-  logToFileByDefault: false, // default setting (overridable by logToFile param)
-  logTimestamp: false, // option to include timestamp in console logs
-  path: 'logs/', // default log directory (relative to main project root directory)
+export interface LogOptions {
+  logToFileByDefault: boolean;
+  logTimestamp: boolean;
+  path: string;
+  prefix: string;
+  suffix: string;
+  filename: string;
+  additionalLogs: Record<string, ColorSetting>;
+  systemLogs: Record<string, ColorSetting>;
+}
+
+const defaultOptions: LogOptions = {
+  logToFileByDefault: false,
+  logTimestamp: false,
+  path: 'logs/',
   prefix: '',
   suffix: '',
-  filename: '', // template for log file name (e.g. 'error-{date}.log'), defaults to '{type}.log'
-
-  // log types with corresponding color settings
+  filename: '',
   additionalLogs: {},
   systemLogs: {
     info: 'cyan',
@@ -25,22 +34,29 @@ const defaultOptions = {
 const optionKeys = Object.keys(defaultOptions);
 
 export default class Log {
-  constructor(options = defaultOptions) {
-    options = {
+  options: LogOptions;
+  color: Color;
+  typeOptions: Record<string, Partial<LogOptions>> = {};
+
+  // Dynamic convenience methods added at runtime
+  [key: string]: unknown;
+
+  constructor(options: Partial<LogOptions> = {}) {
+    const merged: LogOptions = {
       ...defaultOptions,
       ...options,
     };
-    this.options = options;
+    this.options = merged;
     this.options.path = this.sanitizePath(this.options.path);
 
-    const { additionalLogs, systemLogs } = options;
-    const logs = {
+    const { additionalLogs, systemLogs } = merged;
+    const logs: Record<string, ColorSetting> = {
       ...systemLogs,
       ...additionalLogs,
     };
 
     this.color = new Color();
-    this.typeOptions = [];
+    this.typeOptions = {};
 
     // create direct convenience methods for logging
     for (const type of Object.keys(logs)) {
@@ -49,7 +65,7 @@ export default class Log {
   }
 
   // records setting and options for log type, and creates convenience method ie: log.info()
-  defineType(type, setting, options = null) {
+  defineType(type: string, setting: ColorSetting, options: Partial<LogOptions> | null = null): void {
     this.color.setLogColor(type, setting);
 
     // create convenience method if it doesn't exist
@@ -58,56 +74,60 @@ export default class Log {
     if (!options) return;
     if (typeof options !== 'object') throw 'The options param must be an object.';
 
-    for (let option of Object.keys(options)) {
+    for (const option of Object.keys(options)) {
       if (!optionKeys.includes(option)) {
         throw `${option} is not a valid configuration object.`
-        + '\n For a list of available options, see https://github.com/abofs/stonyx-logs#configuration';
+          + '\n For a list of available options, see https://github.com/abofs/stonyx-logs#configuration';
       }
 
       // sanitize path input
-      if (option === 'path') options[option] = this.sanitizePath(options[option]);
+      if (option === 'path') {
+        (options as Record<string, unknown>)[option] = this.sanitizePath(
+          (options as Record<string, unknown>)[option] as string
+        );
+      }
     }
 
     this.typeOptions[type] = options;
   }
 
   // proxy through `logAction` method in order to set defaults based on argument presence
-  createConvenienceMethod(type) {
-    this[type] = (content, logToFile, overwrite = false) =>
+  createConvenienceMethod(type: string): void {
+    (this as Record<string, unknown>)[type] = (content: string, logToFile?: boolean, overwrite = false) =>
       this.logAction(type, content, logToFile, overwrite);
   }
 
   // validates params and sets configuration-based defaults for logging
-  logAction(type, content, logToFile, overwrite) {
+  logAction(type: string, content: string, logToFile?: boolean, overwrite?: boolean): Promise<void> {
     // set logToFile default based on class options when not set
-    if (arguments[2] === undefined) logToFile = this.getOptionForType(type, 'logToFileByDefault');
+    if (logToFile === undefined) logToFile = this.getOptionForType(type, 'logToFileByDefault') as boolean;
 
     // treat overwrite default as true for log type "debug"
-    if (type === 'debug' && arguments[3] === undefined) overwrite = true;
+    if (type === 'debug' && overwrite === undefined) overwrite = true;
 
-    return this.log(content, type, logToFile, overwrite);
+    return this.log(content, type, logToFile, overwrite ?? false);
   }
 
   // retrieves option setting for given type, default to global
-  getOptionForType(type, option) {
+  getOptionForType(type: string, option: keyof LogOptions): LogOptions[keyof LogOptions] {
     const options = this.typeOptions[type];
     if (!options || !options[option]) return this.options[option];
 
-    return options[option];
+    return options[option] as LogOptions[keyof LogOptions];
   }
 
   // exposes chalk for custom color options via defineType
-  chalk() {
+  chalk(): ReturnType<Color['getChalkInstance']> {
     return this.color.getChalkInstance();
   }
 
   // logs to console, and conditionally to file
-  async log(content, type, logToFile, overwrite) {
-    const logTimestamp = this.getOptionForType(type, 'logTimestamp');
+  async log(content: string, type: string, logToFile: boolean, overwrite: boolean): Promise<void> {
+    const logTimestamp = this.getOptionForType(type, 'logTimestamp') as boolean;
     const timestamp = `[${new Date().toLocaleString('en-US')}]`;
     const chalkColorFunction = this.color.getLogColor(type);
-    let prefix = this.getOptionForType(type, 'prefix');
-    let suffix = this.getOptionForType(type, 'suffix');
+    let prefix = this.getOptionForType(type, 'prefix') as string;
+    let suffix = this.getOptionForType(type, 'suffix') as string;
     if (logTimestamp) prefix += `${timestamp} `;
     if (prefix) prefix = chalkColorFunction(prefix);
     if (suffix) suffix = chalkColorFunction(suffix);
@@ -117,32 +137,32 @@ export default class Log {
 
     if (!logToFile) return;
 
-    return this.writeToFile(type, `${timestamp} ${content}\n`, overwrite);
+    await this.writeToFile(type, `${timestamp} ${content}\n`, overwrite);
   }
 
   // direct hardcoded debug method (log to file functionality is limited)
-  async debug(content, logToFile = false, overwrite = true) {
+  async debug(content: unknown, logToFile = false, overwrite = true): Promise<void> {
     console.dir(content, { depth: 6 }); // eslint-disable-line no-console
 
     if (!logToFile) return;
 
-    return this.writeToFile('debug', JSON.stringify(content, null, 2), overwrite);
+    await this.writeToFile('debug', JSON.stringify(content, null, 2), overwrite);
   }
 
-  async writeToFile(type, content, overwrite) {
-    const path = this.getOptionForType(type, 'path');
-    const filenameTemplate = this.getOptionForType(type, 'filename');
+  async writeToFile(type: string, content: string, overwrite: boolean): Promise<void> {
+    const path = this.getOptionForType(type, 'path') as string;
+    const filenameTemplate = this.getOptionForType(type, 'filename') as string;
     const resolvedName = this.resolveFilename(filenameTemplate, type);
     const targetLog = `${path}${resolvedName}`;
     await this.validateFileAndDirectory(path, targetLog);
 
     const fileAction = overwrite ? fsp.writeFile : fsp.appendFile;
 
-    return fileAction(targetLog, content);
+    await fileAction(targetLog, content);
   }
 
   // resolves template variables in a filename string
-  resolveFilename(template, type) {
+  resolveFilename(template: string, type: string): string {
     // default to '{type}.log' when no template is configured
     if (!template) return `${type}.log`;
 
@@ -151,15 +171,15 @@ export default class Log {
     const mm = String(now.getMonth() + 1).padStart(2, '0');
     const dd = String(now.getDate()).padStart(2, '0');
 
-    const variables = {
+    const variables: Record<string, string | number> = {
       date: `${yyyy}-${mm}-${dd}`,
       type,
       pid: process.pid,
       hostname: hostname(),
     };
 
-    const resolved = template.replace(/\{(\w+)\}/g, (match, key) => {
-      return variables[key] !== undefined ? variables[key] : match;
+    const resolved = template.replace(/\{(\w+)\}/g, (match, key: string) => {
+      return variables[key] !== undefined ? String(variables[key]) : match;
     });
 
     // sanitize: prevent path traversal and disallow directory separators
@@ -167,8 +187,8 @@ export default class Log {
   }
 
   // attempts to create file and/or directory if they don't already exist
-  async validateFileAndDirectory(path, targetLog) {
-    const errorMethod = this.error || console.error; // prefer native method unless removed by user
+  async validateFileAndDirectory(path: string, targetLog: string): Promise<void> {
+    const errorMethod = (this.error as ((msg: string) => void) | undefined) || console.error;
 
     mkdirSync(path, { recursive: true });
 
@@ -181,7 +201,7 @@ export default class Log {
   }
 
   // method to conditionally sanitize user configuration input
-  sanitizePath(path) {
+  sanitizePath(path: string): string {
     const moduleDir = projectPath.dirname(fileURLToPath(import.meta.url));
     const delim = moduleDir.includes('node_modules') ? 'node_modules' : 'src';
     const splitDir = moduleDir.split(delim);

--- a/test/unit/color-test.js
+++ b/test/unit/color-test.js
@@ -12,7 +12,7 @@ module('[Unit] Color', function () {
       const color = new Color();
 
       assert.ok(color instanceof Color, 'is a Color instance');
-      assert.deepEqual(color.types, [], 'types starts as empty array');
+      assert.deepEqual(color.types, {}, 'types starts as empty object');
     });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist-test",
+    "declaration": false,
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- Migrates `src/index.js` and `src/color.js` to fully-typed TypeScript with strict mode
- Zero `any` types — exports `LogOptions`, `ChalkColorFn`, `ColorSetting` for consumers
- Adds `dist/` build pipeline matching stonyx-utils/stonyx-events pattern
- Package exports updated to `dist/` with `.d.ts` type declarations
- 53/53 existing tests pass against compiled output

## Validation
| # | Assertion | Status |
|---|-----------|--------|
| 1 | All 53 existing tests pass | :white_check_mark: |
| 2 | Zero `any` types in source (both files) | :white_check_mark: |
| 3 | `strict: true` compiles clean | :white_check_mark: |
| 4 | Type declarations generated (`dist/index.d.ts`, `dist/color.d.ts`) | :white_check_mark: |
| 5 | Package exports point to compiled `dist/` output with types | :white_check_mark: |
| 6 | Dynamic method creation (`this[type]`) properly typed | :white_check_mark: |
| 7 | `typeOptions` and `Color.types` use proper `Record<>` types | :white_check_mark: |
| 8 | chalk dependency types resolve correctly | :white_check_mark: |

## Test plan
- [x] `pnpm test` passes (build + build:test + qunit)
- [x] `tsc --strict` compiles with zero errors
- [x] Type declarations verify correct public API surface

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)