### PR TITLE
fix: replace throw-string with throw-Error across log and color

### DIFF
--- a/src/color.ts
+++ b/src/color.ts
@@ -21,7 +21,7 @@ export default class Color {
 
   // retrieves chalk color function, and fully validates output
   settingToChalkColorFunction(setting: ColorSetting): ChalkColorFn {
-    const errorMessage = 'Invalid chalk color function.'
+    const errorMessage = 'Invalid chalk color function. '
       + 'For help with color settings, see https://github.com/abofs/stonyx-logs#defining-logs--colors';
 
     switch (typeof setting) {
@@ -32,7 +32,7 @@ export default class Color {
       if (!chalkColorFunction
           || typeof chalkColorFunction !== 'function'
           || typeof chalkColorFunction('') !== 'string') {
-        throw errorMessage;
+        throw new Error(errorMessage);
       }
 
       return chalkColorFunction;
@@ -40,13 +40,13 @@ export default class Color {
     case 'function':
       // validate that given function returns a string
       if (typeof setting('') !== 'string') {
-        throw errorMessage;
+        throw new Error(errorMessage);
       }
 
       return setting;
 
     default:
-      throw errorMessage;
+      throw new Error(errorMessage);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,12 +72,12 @@ export default class Log {
     if (!this[type]) this.createConvenienceMethod(type);
 
     if (!options) return;
-    if (typeof options !== 'object') throw 'The options param must be an object.';
+    if (typeof options !== 'object') throw new Error('The options param must be an object.');
 
     for (const option of Object.keys(options)) {
       if (!optionKeys.includes(option)) {
-        throw `${option} is not a valid configuration object.`
-          + '\n For a list of available options, see https://github.com/abofs/stonyx-logs#configuration';
+        throw new Error(`${option} is not a valid configuration object.`
+          + '\n For a list of available options, see https://github.com/abofs/stonyx-logs#configuration');
       }
 
       // sanitize path input
@@ -206,7 +206,7 @@ export default class Log {
     const delim = moduleDir.includes('node_modules') ? 'node_modules' : 'src';
     const splitDir = moduleDir.split(delim);
 
-    if (splitDir.length < 2) throw ('Failed to locate your project\'s root directory.');
+    if (splitDir.length < 2) throw new Error('Failed to locate your project\'s root directory.');
 
     // use project root directory behind path
     path = projectPath.resolve(splitDir[0], path);


### PR DESCRIPTION
## Summary
- Replaced 6 occurrences of `throw 'string literal'` with `throw new Error(...)` across index.ts and color.ts
- Preserves stack traces and enables typed error catching
- Also fixed missing space in chalk error message

Closes #17

## Test plan
- [x] TypeScript compilation passes
- [x] Full test suite passes (53/53)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)