### PR TITLE
docs: add project-level SME templates

### DIFF
--- a/docs/agents/qa-test-engineer.md
+++ b/docs/agents/qa-test-engineer.md
@@ -1,0 +1,45 @@
+# SME Template: QA Test Engineer — Stonyx Logs
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/qa-test-engineer.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-logs`
+**Framework:** Stonyx utility package published to npm as `@stonyx/logs`
+**Domain:** Color-coded console and file logging for Node.js applications, built on top of chalk
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (strict, ESM) |
+| Runtime | Node.js 24.x |
+| Package Manager | pnpm 9 |
+| Build | `tsc` (two configs: `tsconfig.json` for dist, `tsconfig.test.json` for dist-test) |
+| Test Framework | QUnit (unit + integration suites) |
+| Test Doubles | Sinon (stubs/spies for console output and file system) |
+| Dependency | chalk 5.x (ESM-only) |
+| CI | Reusable workflow from `abofs/stonyx-workflows` |
+| Publishing | npm OIDC trusted publishing with alpha/beta/stable channels |
+
+## Architecture Patterns
+
+- Single default export `Log` class in `src/index.ts` with a companion `Color` class in `src/color.ts`
+- Dynamic convenience methods generated at runtime from `systemLogs` and `additionalLogs` config (e.g., `log.info()`, `log.warn()`, `log.error()`)
+- `defineType()` allows post-construction registration of new log types with custom chalk functions or color strings
+- Per-type option overrides via `typeOptions` map (prefix, suffix, path, filename can differ per log type)
+- File logging is async (`fs.promises`) with automatic directory creation via `mkdirSync`
+- Dynamic filename resolution supports `{date}`, `{type}`, `{pid}`, `{hostname}` template variables with path-traversal sanitization
+- `debug()` is a hardcoded method that uses `console.dir` instead of chalk coloring, with `JSON.stringify` for file output
+- Color resolution: string starting with `#` uses `chalk.hex()`, plain strings map to named chalk methods, functions are passed through with validation
+
+## Live Knowledge
+
+- Tests are in plain JS under `test/unit/` (log-test, color-test, filename-test) and `test/integration.js`; they compile from `tsconfig.test.json` into `dist-test/`
+- The `pnpm test` script chains `build`, `build:test`, then runs QUnit on `dist-test/test/unit/**/*-test.js`
+- chalk 5.x is ESM-only, so the project must use `"type": "module"` and `.js` extensions in imports
+- The package exports two entry points: `.` (default Log class) and `./color` (Color class)
+- `sanitizePath()` resolves log file paths relative to the consumer's project root by splitting on `node_modules` or `src`
+- File write operations return promises, allowing `await log.error('msg', true)` for guaranteed write completion
+- `logToFile` parameter defaults to `false` unless `logToFileByDefault` is set in constructor options

--- a/docs/agents/validation-loop-team.md
+++ b/docs/agents/validation-loop-team.md
@@ -1,0 +1,44 @@
+# SME Template: Validation Loop Team — Stonyx Logs
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/validation-loop-team.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-logs`
+**Framework:** Stonyx utility package published to npm as `@stonyx/logs`
+**Domain:** Color-coded console and file logging for Node.js applications, built on top of chalk
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (strict, ESM) |
+| Runtime | Node.js 24.x |
+| Package Manager | pnpm 9 |
+| Build | `tsc` (two configs: `tsconfig.json` for dist, `tsconfig.test.json` for dist-test) |
+| Test Framework | QUnit (unit + integration suites) |
+| Test Doubles | Sinon (stubs/spies for console output and file system) |
+| Dependency | chalk 5.x (ESM-only) |
+| CI | Reusable workflow from `abofs/stonyx-workflows` |
+| Publishing | npm OIDC trusted publishing with alpha/beta/stable channels |
+
+## Architecture Patterns
+
+- Two-class design: `Log` (orchestrator) delegates color resolution to `Color` (chalk wrapper)
+- Constructor merges `systemLogs` defaults (`info: cyan`, `warn: yellow`, `error: red`) with user-provided `additionalLogs`
+- Runtime method generation: `createConvenienceMethod()` attaches logging functions to the `Log` instance via index signature `[key: string]: unknown`
+- Option resolution chain: per-type overrides in `typeOptions[type]` fall back to global `this.options`
+- File operations: async write/append via `fs.promises`, synchronous directory creation via `mkdirSync({ recursive: true })`
+- Filename templating with `resolveFilename()` supports `{date}`, `{type}`, `{pid}`, `{hostname}` variables; sanitizes path traversal characters
+- The `debug()` method is hardcoded separately from the dynamic method system, using `console.dir` with depth 6
+
+## Live Knowledge
+
+- The codebase is compact: only two source files (`src/index.ts`, `src/color.ts`) totaling ~270 lines
+- No external dependencies beyond chalk; all file I/O uses Node built-ins (`fs`, `path`, `os`, `url`)
+- `settingToChalkColorFunction()` in Color validates that the resolved function actually returns a string, preventing silent misconfiguration
+- `validateFileAndDirectory()` creates missing log directories and files on demand but swallows file-creation errors with a logged warning rather than throwing
+- The package uses dual exports (`"."` and `"./color"`) so consumers can import the Color class independently
+- Test suite covers unit tests (log-test, color-test, filename-test) and integration tests; runs via `pnpm test` which builds both source and test TypeScript before executing QUnit
+- Alpha versions are published on PR, beta on merge to main, stable on manual dispatch -- all managed by the shared `stonyx-workflows` npm-publish workflow


### PR DESCRIPTION
## Summary
- Add `docs/agents/qa-test-engineer.md` and `docs/agents/validation-loop-team.md` project-level SME templates
- Templates inherit from beatrix-shared base templates and layer stonyx-logs-specific context (chalk-based color system, dual-class architecture, dynamic filename resolution, QUnit test structure)

## Test plan
- [ ] Verify templates follow the required format (inherits-from header, Project Context, Tech Stack table, Architecture Patterns, Live Knowledge)
- [ ] Confirm project-specific details are accurate against current source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)