### PR TITLE
fix: add prepublishOnly build hook so dist/ ships in tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "node --import tsx node_modules/qunit/bin/qunit.js 'test/**/*-test.ts'",
-    "lint": "eslint . --fix"
+    "lint": "eslint . --fix",
+    "prepublishOnly": "npm run build && npm test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #23.

## Problem

`@stonyx/logs@1.0.1-beta.15` shipped with an empty `dist/`. Tarball contained only `LICENSE`, `README.md`, `package.json`. Every downstream consumer importing `@stonyx/logs` failed with `ERR_MODULE_NOT_FOUND`.

## Root Cause

PR #21 replaced the JS-build-and-run test script with a tsx on-the-fly version:

```diff
- "test": "pnpm build && pnpm build:test && qunit 'dist-test/test/**/*-test.js'"
+ "test": "node --import tsx node_modules/qunit/bin/qunit.js 'test/**/*-test.ts'"
```

That was correct for testing, but the old script's `pnpm build` side-effect was the only thing populating `dist/` before the publish workflow packed the tarball. With no build step in the test script and no `prepublishOnly` hook, `pnpm publish` packed an empty `dist/`.

## Fix

Adopt the canonical pattern stonyx-events already uses:

```json
"prepublishOnly": "npm run build && npm test"
```

Every publish path (cascade, manual workflow_dispatch, local `pnpm publish`) now builds before packing — independent of what `test` does.

## Verification

Locally, with a clean `dist/` removed:

```
$ rm -rf dist && pnpm publish --dry-run --no-git-checks --tag beta
...
# pass 65
# skip 0
# todo 0
# fail 0
...
npm notice Tarball Contents
npm notice 35.1kB LICENSE
npm notice 12.1kB README.md
npm notice 415B dist/color.d.ts
npm notice 1.5kB dist/color.js
npm notice 1.4kB dist/index.d.ts
npm notice 7.3kB dist/index.js
npm notice 1.5kB package.json
```

Build runs, tests pass, `dist/` ships.

## Downstream Impact

Unblocks stonyx PR #56 (Sprint 45 Story A1) and the rest of the bottom-up dep-tree cascade. Next beta (presumably beta.16) will be adoptable upstream.

## SME Roster

- **Convention** — one-line script addition, matches stonyx-events verbatim
- **Security** — no-op surface; hook only runs at publish time