### PR TITLE
fix(log): explicit declare for system-defined log types so info/warn/error compile under strict mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,11 @@ export default class Log {
   // Dynamic convenience methods added at runtime
   [key: string]: unknown;
 
+  // Explicit declarations for system-defined log types so they remain callable under strict mode.
+  declare info: (content: string, logToFile?: boolean, overwrite?: boolean) => Promise<void>;
+  declare warn: (content: string, logToFile?: boolean, overwrite?: boolean) => Promise<void>;
+  declare error: (content: string, logToFile?: boolean, overwrite?: boolean) => Promise<void>;
+
   constructor(options: Partial<LogOptions> = {}) {
     const merged: LogOptions = {
       ...defaultOptions,
@@ -188,7 +193,7 @@ export default class Log {
 
   // attempts to create file and/or directory if they don't already exist
   async validateFileAndDirectory(path: string, targetLog: string): Promise<void> {
-    const errorMethod = (this.error as ((msg: string) => void) | undefined) || console.error;
+    const errorMethod = this.error;
 
     mkdirSync(path, { recursive: true });
 

--- a/test/unit/log-test.ts
+++ b/test/unit/log-test.ts
@@ -236,3 +236,18 @@ module('[Unit] Log', function (hooks) {
     });
   });
 });
+
+module('[Unit] Log convenience methods (system types)', function () {
+  test('info, warn, error are callable on a default-constructed Log', function (assert) {
+    const log = new Log();
+    assert.strictEqual(typeof log.info, 'function', 'log.info is a function');
+    assert.strictEqual(typeof log.warn, 'function', 'log.warn is a function');
+    assert.strictEqual(typeof log.error, 'function', 'log.error is a function');
+
+    void log.info('refined-test info');
+    void log.warn('refined-test warn');
+    void log.error('refined-test error');
+
+    assert.ok(true, 'direct calls compiled and executed');
+  });
+});


### PR DESCRIPTION
## Summary

Add explicit `declare` declarations for `info`, `warn`, `error` on the `Log` class so downstream `@stonyx/*` modules and external consumers can call them directly under `tsc --strict` without `as`-cast workarounds.

The `[key: string]: unknown` index signature on `Log` (added so user-defined log types can be added via `defineType` at runtime) was shadowing the dynamically-created system-method types. With explicit declarations, the system-defined types are statically callable; user-defined types continue to flow through the index signature.

Also simplifies the internal `validateFileAndDirectory` cast that was working around the same quirk: drops the `(this.error as ...)` cast and the `|| console.error` fallback (which was defending against an impossible state — the constructor unconditionally calls `defineType('error', ...)` since `defaultOptions.systemLogs.error: 'red'` is hardcoded).

Closes abofs/stonyx-logs#25.

## Behavior change

Strict superset, non-breaking. Consumers with prior cast workarounds continue to compile (cast becomes redundant but harmless). Consumers calling `log.warn('x')` directly previously hit `TS18046`; they now compile clean.

## Validation

Tier-2 unit (QUnit + TypeScript). All 6 assertions green:

1. `pnpm exec tsc --noEmit` -> exit 0
2. `pnpm build` -> exit 0; emitted `dist/index.d.ts` carries the three explicit declarations:
   ```ts
   info: (content: string, logToFile?: boolean, overwrite?: boolean) => Promise<void>;
   warn: (content: string, logToFile?: boolean, overwrite?: boolean) => Promise<void>;
   error: (content: string, logToFile?: boolean, overwrite?: boolean) => Promise<void>;
   ```
3. `pnpm test` -> all 66 tests green (was 65 before this PR; new test brings it to 66)
4. New test asserts `typeof log.info === 'function'` etc. — passes
5. New test FILE compiles — direct unprefixed calls (`void log.info('refined-test info')` etc.) without any `as` casts. Confirmed by assertion 1 + assertion 3 succeeding.
6. **Ephemeral strict-mode consumer-smoke:** scratch consumer at `/tmp/stonyx-logs-25-smoke/smoke.ts` (calling `log.info('smoke-info')`, `log.warn('smoke-warn', true)`, `log.error('smoke-error', true, true)`, `const p: Promise<void> = log.info('promise-shape')`, `const userType: unknown = log.someUserType`) compiled clean against the new `dist/`:
   ```
   $ pnpm exec tsc --project /tmp/stonyx-logs-25-smoke/tsconfig.json
   EXIT=0
   ```
   Scratch consumer was NOT committed.

## Docs

No README change — the README's existing usage examples (e.g., `log.info('message')`) already show the call form that newly compiles. No surface-level docs describe convenience-method typing at the API-shape level.

## Refinement

Spec: `beatrix-shared:projects/stonyx/sprints/refinement-sprint-47.md`
End-to-end compile-checked at refinement time before this implementation began.